### PR TITLE
Update nokogiri 1.8.0 -> 1.8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,6 @@ gem 'rest-client'
 gem 'chartkick'
 gem 'pry'
 
-
-
 group :development, :test do
   gem 'byebug', '9.0.6', platform: :mri
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,13 +85,13 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
     multi_json (1.12.1)
     netrc (0.11.0)
     nio4r (2.1.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -221,4 +221,4 @@ DEPENDENCIES
   web-console (= 3.5.1)
 
 BUNDLED WITH
-   1.15.3
+   1.16.1


### PR DESCRIPTION
Nokogiri 1.8.0 has a security vulnerability (http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9050). Updating to the patched version.

(GitHub pinged me about this, so I'm PR'ing.)